### PR TITLE
Try consuming the futures before closing in FlightStreamQueue

### DIFF
--- a/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/utils/FlightStreamQueue.java
+++ b/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/utils/FlightStreamQueue.java
@@ -180,7 +180,7 @@ public class FlightStreamQueue implements AutoCloseable {
     }));
   }
 
-  public static boolean isCallStatusCancelled(final Exception e) {
+  private static boolean isCallStatusCancelled(final Exception e) {
     return e.getCause() instanceof FlightRuntimeException &&
         ((FlightRuntimeException) e.getCause()).status().code() == CallStatus.CANCELLED.code();
   }


### PR DESCRIPTION
The leak was occurring because of a race condition when closing the FlightStreamQueue: 
`FlightStreamQueue#close` was closing the FlightStream at the same time when other threads (on CompletionService) are executing `FlightStream#next`.

The approach to solve this is to:
- Cancel the FlightStreams, signaling the server that it should no longer process data, but buffered data can still be streamed
- Wait for `FlightStream#next` calls running in parallel to finish
- Close FlightStreams at the end