### PR TITLE
Use Avatica DateTimeUtils for getString in Date/Time/TimeStamp

### DIFF
--- a/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessor.java
+++ b/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessor.java
@@ -37,6 +37,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.function.IntSupplier;
 
 /**
@@ -51,6 +52,7 @@ public abstract class ArrowFlightJdbcAccessor implements Accessor {
 
   protected ArrowFlightJdbcAccessor(final IntSupplier currentRowSupplier,
                                     ArrowFlightJdbcAccessorFactory.WasNullConsumer wasNullConsumer) {
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC")); // set default TZ to UTC to avoid zone offset in Date/Time objects
     this.currentRowSupplier = currentRowSupplier;
     this.wasNullConsumer = wasNullConsumer;
   }

--- a/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessor.java
+++ b/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/ArrowFlightJdbcAccessor.java
@@ -37,7 +37,6 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Map;
-import java.util.TimeZone;
 import java.util.function.IntSupplier;
 
 /**
@@ -52,7 +51,6 @@ public abstract class ArrowFlightJdbcAccessor implements Accessor {
 
   protected ArrowFlightJdbcAccessor(final IntSupplier currentRowSupplier,
                                     ArrowFlightJdbcAccessorFactory.WasNullConsumer wasNullConsumer) {
-    TimeZone.setDefault(TimeZone.getTimeZone("UTC")); // set default TZ to UTC to avoid zone offset in Date/Time objects
     this.currentRowSupplier = currentRowSupplier;
     this.wasNullConsumer = wasNullConsumer;
   }

--- a/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDateVectorAccessor.java
+++ b/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcDateVectorAccessor.java
@@ -20,6 +20,7 @@ package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcDateVectorGetter.Getter;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcDateVectorGetter.Holder;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcDateVectorGetter.createGetter;
+import static org.apache.calcite.avatica.util.DateTimeUtils.unixDateToString;
 
 import java.sql.Date;
 import java.sql.Timestamp;
@@ -104,6 +105,12 @@ public class ArrowFlightJdbcDateVectorAccessor extends ArrowFlightJdbcAccessor {
       return null;
     }
     return new Timestamp(date.getTime());
+  }
+
+  @Override
+  public String getString() {
+    long milliseconds = timeUnit.toMillis(holder.value);
+    return unixDateToString((int) milliseconds);
   }
 
   protected static TimeUnit getTimeUnitForVector(ValueVector vector) {

--- a/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
+++ b/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeStampVectorAccessor.java
@@ -20,6 +20,7 @@ package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorGetter.Getter;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorGetter.Holder;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeStampVectorGetter.createGetter;
+import static org.apache.calcite.avatica.util.DateTimeUtils.unixTimestampToString;
 
 import java.sql.Date;
 import java.sql.Time;
@@ -129,6 +130,12 @@ public class ArrowFlightJdbcTimeStampVectorAccessor extends ArrowFlightJdbcAcces
     }
 
     return Timestamp.valueOf(localDateTime);
+  }
+
+  @Override
+  public String getString() {
+    long milliseconds = timeUnit.toMillis(holder.value);
+    return unixTimestampToString((int) milliseconds);
   }
 
   protected static TimeUnit getTimeUnitForVector(TimeStampVector vector) {

--- a/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeVectorAccessor.java
+++ b/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/calendar/ArrowFlightJdbcTimeVectorAccessor.java
@@ -20,6 +20,7 @@ package org.apache.arrow.driver.jdbc.accessor.impl.calendar;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeVectorGetter.Getter;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeVectorGetter.Holder;
 import static org.apache.arrow.driver.jdbc.accessor.impl.calendar.ArrowFlightJdbcTimeVectorGetter.createGetter;
+import static org.apache.calcite.avatica.util.DateTimeUtils.unixTimeToString;
 
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -136,6 +137,12 @@ public class ArrowFlightJdbcTimeVectorAccessor extends ArrowFlightJdbcAccessor {
       return null;
     }
     return new Timestamp(time.getTime());
+  }
+
+  @Override
+  public String getString() {
+    long milliseconds = timeUnit.toMillis(holder.value);
+    return unixTimeToString((int) milliseconds);
   }
 
   protected static TimeUnit getTimeUnitForVector(ValueVector vector) {


### PR DESCRIPTION
Some accessor methods that rely on java.sql Date, Time, and Timestamp objects were having the wrong String value when `toString` was called. This is due to the getString method using these object's toString method to produce a response. This would end up using the zone offset when producing the return value.