### PR TITLE
Add support for getUnicodeStream for Text and Binary accessors

### DIFF
--- a/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/binary/ArrowFlightJdbcBinaryVectorAccessor.java
+++ b/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/binary/ArrowFlightJdbcBinaryVectorAccessor.java
@@ -18,17 +18,10 @@
 package org.apache.arrow.driver.jdbc.accessor.impl.binary;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.CharArrayReader;
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.io.Reader;
-import java.io.Writer;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.sql.SQLException;
 import java.util.function.IntSupplier;
 
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
@@ -103,31 +96,23 @@ public class ArrowFlightJdbcBinaryVectorAccessor extends ArrowFlightJdbcAccessor
   }
 
   @Override
-  public InputStream getAsciiStream() throws SQLException {
+  public InputStream getAsciiStream() {
     byte[] bytes = getBytes();
     if (bytes == null) {
       return null;
     }
 
-    try {
-      return new ByteArrayInputStream(convertByteArrayEncoding(bytes, StandardCharsets.US_ASCII));
-    } catch (final IOException e) {
-      throw new SQLException("Failed to create InputStream", e);
-    }
+    return new ByteArrayInputStream(bytes);
   }
 
   @Override
-  public InputStream getUnicodeStream() throws SQLException {
+  public InputStream getUnicodeStream() {
     byte[] bytes = getBytes();
     if (bytes == null) {
       return null;
     }
 
-    try {
-      return new ByteArrayInputStream(convertByteArrayEncoding(bytes, StandardCharsets.UTF_8));
-    } catch (final IOException e) {
-      throw new SQLException("Failed to create InputStream", e);
-    }
+    return new ByteArrayInputStream(bytes);
   }
 
   @Override
@@ -148,21 +133,5 @@ public class ArrowFlightJdbcBinaryVectorAccessor extends ArrowFlightJdbcAccessor
     }
 
     return new CharArrayReader(string.toCharArray());
-  }
-
-  private byte[] convertByteArrayEncoding(final byte[] originalArray, final Charset outputEncoding) throws IOException {
-    final ByteArrayInputStream original = new ByteArrayInputStream(originalArray);
-    final InputStreamReader contentReader = new InputStreamReader(original, StandardCharsets.UTF_8);
-
-    int readCount;
-    char[] buffer = new char[4096];
-    try (ByteArrayOutputStream converted = new ByteArrayOutputStream()) {
-      try (Writer writer = new OutputStreamWriter(converted, outputEncoding)) {
-        while ((readCount = contentReader.read(buffer, 0, buffer.length)) != -1) {
-          writer.write(buffer, 0, readCount);
-        }
-      }
-      return converted.toByteArray();
-    }
   }
 }

--- a/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/binary/ArrowFlightJdbcBinaryVectorAccessor.java
+++ b/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/binary/ArrowFlightJdbcBinaryVectorAccessor.java
@@ -18,10 +18,17 @@
 package org.apache.arrow.driver.jdbc.accessor.impl.binary;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.CharArrayReader;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
 import java.util.function.IntSupplier;
 
 import org.apache.arrow.driver.jdbc.accessor.ArrowFlightJdbcAccessor;
@@ -96,13 +103,31 @@ public class ArrowFlightJdbcBinaryVectorAccessor extends ArrowFlightJdbcAccessor
   }
 
   @Override
-  public InputStream getAsciiStream() {
+  public InputStream getAsciiStream() throws SQLException {
     byte[] bytes = getBytes();
     if (bytes == null) {
       return null;
     }
 
-    return new ByteArrayInputStream(bytes);
+    try {
+      return new ByteArrayInputStream(convertByteArrayEncoding(bytes, StandardCharsets.US_ASCII));
+    } catch (final IOException e) {
+      throw new SQLException("Failed to create InputStream", e);
+    }
+  }
+
+  @Override
+  public InputStream getUnicodeStream() throws SQLException {
+    byte[] bytes = getBytes();
+    if (bytes == null) {
+      return null;
+    }
+
+    try {
+      return new ByteArrayInputStream(convertByteArrayEncoding(bytes, StandardCharsets.UTF_8));
+    } catch (final IOException e) {
+      throw new SQLException("Failed to create InputStream", e);
+    }
   }
 
   @Override
@@ -123,5 +148,21 @@ public class ArrowFlightJdbcBinaryVectorAccessor extends ArrowFlightJdbcAccessor
     }
 
     return new CharArrayReader(string.toCharArray());
+  }
+
+  private byte[] convertByteArrayEncoding(final byte[] originalArray, final Charset outputEncoding) throws IOException {
+    final ByteArrayInputStream original = new ByteArrayInputStream(originalArray);
+    final InputStreamReader contentReader = new InputStreamReader(original, StandardCharsets.UTF_8);
+
+    int readCount;
+    char[] buffer = new char[4096];
+    try (ByteArrayOutputStream converted = new ByteArrayOutputStream()) {
+      try (Writer writer = new OutputStreamWriter(converted, outputEncoding)) {
+        while ((readCount = contentReader.read(buffer, 0, buffer.length)) != -1) {
+          writer.write(buffer, 0, readCount);
+        }
+      }
+      return converted.toByteArray();
+    }
   }
 }

--- a/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessor.java
+++ b/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessor.java
@@ -104,7 +104,7 @@ public class ArrowFlightJdbcVarCharVectorAccessor extends ArrowFlightJdbcAccesso
 
   @Override
   public boolean getBoolean() throws SQLException {
-    final String value = getString();
+    String value = getString();
     if (value == null || value.equalsIgnoreCase("false") || value.equals("0")) {
       return false;
     } else if (value.equalsIgnoreCase("true") || value.equals("1")) {

--- a/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessor.java
+++ b/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessor.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.driver.jdbc.accessor.impl.text;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.ByteArrayInputStream;
 import java.io.CharArrayReader;
 import java.io.InputStream;
@@ -101,7 +104,7 @@ public class ArrowFlightJdbcVarCharVectorAccessor extends ArrowFlightJdbcAccesso
 
   @Override
   public boolean getBoolean() throws SQLException {
-    String value = getString();
+    final String value = getString();
     if (value == null || value.equalsIgnoreCase("false") || value.equals("0")) {
       return false;
     } else if (value.equalsIgnoreCase("true") || value.equals("1")) {
@@ -185,8 +188,14 @@ public class ArrowFlightJdbcVarCharVectorAccessor extends ArrowFlightJdbcAccesso
 
   @Override
   public InputStream getAsciiStream() {
-    Text value = this.getText();
-    return value == null ? null : new ByteArrayInputStream(value.getBytes(), 0, value.getLength());
+    final String value = getString();
+    return value == null ? null : new ByteArrayInputStream(value.getBytes(US_ASCII), 0, value.length());
+  }
+
+  @Override
+  public InputStream getUnicodeStream() {
+    final String value = getString();
+    return value == null ? null : new ByteArrayInputStream(value.getBytes(UTF_8), 0, value.length());
   }
 
   @Override

--- a/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessor.java
+++ b/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessor.java
@@ -18,7 +18,6 @@
 package org.apache.arrow.driver.jdbc.accessor.impl.text;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.ByteArrayInputStream;
 import java.io.CharArrayReader;
@@ -188,14 +187,22 @@ public class ArrowFlightJdbcVarCharVectorAccessor extends ArrowFlightJdbcAccesso
 
   @Override
   public InputStream getAsciiStream() {
-    final String value = getString();
-    return value == null ? null : new ByteArrayInputStream(value.getBytes(US_ASCII), 0, value.length());
+    final String textValue = getString();
+    if (textValue == null) {
+      return null;
+    }
+    // Text is always UTF-8, so we have to encode back to ASCII
+    return new ByteArrayInputStream(textValue.getBytes(US_ASCII));
   }
 
   @Override
   public InputStream getUnicodeStream() {
-    final String value = getString();
-    return value == null ? null : new ByteArrayInputStream(value.getBytes(UTF_8), 0, value.length());
+    final Text textValue = getText();
+    if (textValue == null) {
+      return null;
+    }
+    // Already in UTF-8
+    return new ByteArrayInputStream(textValue.getBytes(), 0, textValue.getLength());
   }
 
   @Override

--- a/java/flight/flight-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/binary/ArrowFlightJdbcBinaryVectorAccessorTest.java
+++ b/java/flight/flight-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/binary/ArrowFlightJdbcBinaryVectorAccessorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.driver.jdbc.accessor.impl.binary;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.is;
 
 import java.io.InputStream;
@@ -107,7 +109,7 @@ public class ArrowFlightJdbcBinaryVectorAccessorTest {
   @Test
   public void testShouldGetStringReturnExpectedString() throws Exception {
     accessorIterator.assertAccessorGetter(vector, ArrowFlightJdbcBinaryVectorAccessor::getString,
-        (accessor) -> is(new String(accessor.getBytes(), StandardCharsets.UTF_8)));
+        (accessor) -> is(new String(accessor.getBytes(), UTF_8)));
   }
 
   @Test
@@ -165,7 +167,7 @@ public class ArrowFlightJdbcBinaryVectorAccessorTest {
   public void testShouldGetUnicodeStreamReturnCorrectInputStream() throws Exception {
     accessorIterator.iterate(vector, (accessor, currentRow) -> {
       InputStream inputStream = accessor.getUnicodeStream();
-      String actualString = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+      String actualString = IOUtils.toString(inputStream, UTF_8);
       collector.checkThat(accessor.wasNull(), is(false));
       collector.checkThat(actualString, is(accessor.getString()));
     });
@@ -185,7 +187,7 @@ public class ArrowFlightJdbcBinaryVectorAccessorTest {
   public void testShouldGetAsciiStreamReturnCorrectInputStream() throws Exception {
     accessorIterator.iterate(vector, (accessor, currentRow) -> {
       InputStream inputStream = accessor.getAsciiStream();
-      String actualString = IOUtils.toString(inputStream, StandardCharsets.US_ASCII);
+      String actualString = IOUtils.toString(inputStream, US_ASCII);
       collector.checkThat(accessor.wasNull(), is(false));
       collector.checkThat(actualString, is(accessor.getString()));
     });
@@ -205,7 +207,7 @@ public class ArrowFlightJdbcBinaryVectorAccessorTest {
   public void testShouldGetBinaryStreamReturnCurrentInputStream() throws Exception {
     accessorIterator.iterate(vector, (accessor, currentRow) -> {
       InputStream inputStream = accessor.getBinaryStream();
-      String actualString = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+      String actualString = IOUtils.toString(inputStream, UTF_8);
       collector.checkThat(accessor.wasNull(), is(false));
       collector.checkThat(actualString, is(accessor.getString()));
     });

--- a/java/flight/flight-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/binary/ArrowFlightJdbcBinaryVectorAccessorTest.java
+++ b/java/flight/flight-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/binary/ArrowFlightJdbcBinaryVectorAccessorTest.java
@@ -162,10 +162,30 @@ public class ArrowFlightJdbcBinaryVectorAccessorTest {
   }
 
   @Test
+  public void testShouldGetUnicodeStreamReturnCorrectInputStream() throws Exception {
+    accessorIterator.iterate(vector, (accessor, currentRow) -> {
+      InputStream inputStream = accessor.getUnicodeStream();
+      String actualString = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+      collector.checkThat(accessor.wasNull(), is(false));
+      collector.checkThat(actualString, is(accessor.getString()));
+    });
+  }
+
+  @Test
+  public void testShouldGetUnicodeStreamReturnNull() throws Exception {
+    vector.reset();
+    vector.setValueCount(5);
+
+    ArrowFlightJdbcBinaryVectorAccessor accessor = accessorSupplier.supply(vector, () -> 0);
+    collector.checkThat(accessor.getUnicodeStream(), CoreMatchers.equalTo(null));
+    collector.checkThat(accessor.wasNull(), is(true));
+  }
+
+  @Test
   public void testShouldGetAsciiStreamReturnCorrectInputStream() throws Exception {
     accessorIterator.iterate(vector, (accessor, currentRow) -> {
       InputStream inputStream = accessor.getAsciiStream();
-      String actualString = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+      String actualString = IOUtils.toString(inputStream, StandardCharsets.US_ASCII);
       collector.checkThat(accessor.wasNull(), is(false));
       collector.checkThat(actualString, is(accessor.getString()));
     });

--- a/java/flight/flight-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/binary/ArrowFlightJdbcBinaryVectorAccessorTest.java
+++ b/java/flight/flight-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/binary/ArrowFlightJdbcBinaryVectorAccessorTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.CoreMatchers.is;
 
 import java.io.InputStream;
 import java.io.Reader;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Supplier;

--- a/java/flight/flight-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessorTest.java
+++ b/java/flight/flight-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessorTest.java
@@ -45,6 +45,7 @@ import org.apache.arrow.vector.DateMilliVector;
 import org.apache.arrow.vector.TimeMilliVector;
 import org.apache.arrow.vector.TimeStampVector;
 import org.apache.arrow.vector.util.Text;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -655,14 +656,13 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
   @Test
   public void testShouldGetAsciiStreamReturnValidInputStream() throws Exception {
     Text valueText = new Text("Value for Test.");
-    String valueAscii = new String(valueText.getBytes(), US_ASCII);
+    byte[] valueAscii = valueText.toString().getBytes(US_ASCII);
     when(getter.get(0)).thenReturn(valueText);
 
     try (final InputStream result = accessor.getAsciiStream()) {
       byte[] resultBytes = toByteArray(result);
 
-      collector.checkThat(new String(resultBytes, US_ASCII),
-          equalTo(valueAscii));
+      Assert.assertArrayEquals(valueAscii, resultBytes);
     }
   }
 

--- a/java/flight/flight-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessorTest.java
+++ b/java/flight/flight-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessorTest.java
@@ -639,15 +639,29 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
   }
 
   @Test
-  public void testShouldGetAsciiStreamReturnValidInputStream() throws Exception {
+  public void testShouldGetUnicodeStreamReturnValidInputStream() throws Exception {
     Text value = new Text("Value for Test.");
     when(getter.get(0)).thenReturn(value);
 
-    try (InputStream result = accessor.getAsciiStream()) {
+    try (final InputStream result = accessor.getUnicodeStream()) {
       byte[] resultBytes = toByteArray(result);
 
-      collector.checkThat(new String(resultBytes, StandardCharsets.UTF_8),
+      collector.checkThat(new String(resultBytes, StandardCharsets.US_ASCII),
           equalTo(value.toString()));
+    }
+  }
+
+  @Test
+  public void testShouldGetAsciiStreamReturnValidInputStream() throws Exception {
+    String valueAscii = new String("Value for Test.".getBytes(StandardCharsets.UTF_8), StandardCharsets.US_ASCII);
+    Text valueText = new Text("Value for Test.");
+    when(getter.get(0)).thenReturn(valueText);
+
+    try (final InputStream result = accessor.getAsciiStream()) {
+      byte[] resultBytes = toByteArray(result);
+
+      collector.checkThat(new String(resultBytes, StandardCharsets.US_ASCII),
+          equalTo(valueAscii));
     }
   }
 

--- a/java/flight/flight-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessorTest.java
+++ b/java/flight/flight-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessorTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.when;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.SQLException;
 import java.sql.Time;

--- a/java/flight/flight-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessorTest.java
+++ b/java/flight/flight-jdbc-driver/src/test/java/org/apache/arrow/driver/jdbc/accessor/impl/text/ArrowFlightJdbcVarCharVectorAccessorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.driver.jdbc.accessor.impl.text;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.io.IOUtils.toByteArray;
 import static org.apache.commons.io.IOUtils.toCharArray;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -635,7 +637,7 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
     final byte[] result = accessor.getBytes();
 
     collector.checkThat(result, instanceOf(byte[].class));
-    collector.checkThat(result, equalTo(value.toString().getBytes(StandardCharsets.UTF_8)));
+    collector.checkThat(result, equalTo(value.toString().getBytes(UTF_8)));
   }
 
   @Test
@@ -646,21 +648,21 @@ public class ArrowFlightJdbcVarCharVectorAccessorTest {
     try (final InputStream result = accessor.getUnicodeStream()) {
       byte[] resultBytes = toByteArray(result);
 
-      collector.checkThat(new String(resultBytes, StandardCharsets.US_ASCII),
+      collector.checkThat(new String(resultBytes, UTF_8),
           equalTo(value.toString()));
     }
   }
 
   @Test
   public void testShouldGetAsciiStreamReturnValidInputStream() throws Exception {
-    String valueAscii = new String("Value for Test.".getBytes(StandardCharsets.UTF_8), StandardCharsets.US_ASCII);
     Text valueText = new Text("Value for Test.");
+    String valueAscii = new String(valueText.getBytes(), US_ASCII);
     when(getter.get(0)).thenReturn(valueText);
 
     try (final InputStream result = accessor.getAsciiStream()) {
       byte[] resultBytes = toByteArray(result);
 
-      collector.checkThat(new String(resultBytes, StandardCharsets.US_ASCII),
+      collector.checkThat(new String(resultBytes, US_ASCII),
           equalTo(valueAscii));
     }
   }


### PR DESCRIPTION
Some applications still use getUnicodeStream, even though it has been deprecated for a while.
This PR adds support to getUnicodeStream where it is needed.

https://download.oracle.com/otn-pub/jcp/jdbc-4_1-mrel-spec/jdbc4.1-fr-spec.pdf (page 211)