### PR TITLE
Fix attributes as headers bug and token value parsing error

### DIFF
--- a/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcDriver.java
+++ b/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/ArrowFlightJdbcDriver.java
@@ -27,12 +27,12 @@ import java.io.Reader;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 
 import org.apache.arrow.driver.jdbc.utils.ArrowFlightConnectionConfigImpl.ArrowFlightConnectionProperty;
+import org.apache.arrow.driver.jdbc.utils.UrlParser;
 import org.apache.arrow.flight.FlightRuntimeException;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.Preconditions;
@@ -40,8 +40,6 @@ import org.apache.calcite.avatica.AvaticaConnection;
 import org.apache.calcite.avatica.DriverVersion;
 import org.apache.calcite.avatica.Meta;
 import org.apache.calcite.avatica.UnregisteredDriver;
-import org.apache.calcite.avatica.org.apache.http.NameValuePair;
-import org.apache.calcite.avatica.org.apache.http.client.utils.URLEncodedUtils;
 
 /**
  * JDBC driver for querying data from an Apache Arrow Flight server.
@@ -248,8 +246,8 @@ public class ArrowFlightJdbcDriver extends UnregisteredDriver {
 
     final String extraParams = uri.getRawQuery(); // optional params
 
-    final List<NameValuePair> keyValuePairs = URLEncodedUtils.parse(extraParams, StandardCharsets.UTF_8);
-    keyValuePairs.forEach(p -> resultMap.put(p.getName(), p.getValue()));
+    final Map<String, String> keyValuePairs = UrlParser.parse(extraParams, "&");
+    resultMap.putAll(keyValuePairs);
 
     return resultMap;
   }

--- a/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/utils/UrlParser.java
+++ b/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/utils/UrlParser.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.driver.jdbc.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * URL Parser for extracting key values from a connection string.
+ */
+public class UrlParser {
+  /**
+   * Parse a url key value parameters.
+   *
+   * @param url {@link String}
+   * @return {@link Map}
+   */
+  public static Map<String, String> parse(String url, String separator) {
+    Map<String, String> resultMap = new HashMap<>();
+    String[] keyValues = url.split(separator);
+
+    for (String keyValue : keyValues) {
+      int separatorKey = keyValue.indexOf("="); // Find the first equal sign to split key and value.
+      String key = keyValue.substring(0, separatorKey);
+      String value = keyValue.substring(separatorKey + 1);
+      resultMap.put(key, value);
+    }
+
+    return resultMap;
+  }
+}

--- a/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/utils/UrlParser.java
+++ b/java/flight/flight-jdbc-driver/src/main/java/org/apache/arrow/driver/jdbc/utils/UrlParser.java
@@ -37,7 +37,10 @@ public class UrlParser {
     for (String keyValue : keyValues) {
       int separatorKey = keyValue.indexOf("="); // Find the first equal sign to split key and value.
       String key = keyValue.substring(0, separatorKey);
-      String value = keyValue.substring(separatorKey + 1);
+      String value = "";
+      if (!keyValue.endsWith("=")) { // Avoid crashes for empty values.
+        value = keyValue.substring(separatorKey + 1);
+      }
       resultMap.put(key, value);
     }
 


### PR DESCRIPTION
Fix all attributes being passed as headers by JDBC driver and a bug when parsing tokens values in URLs, in this bug all plus sign were being replaced by blank spaces by the Avatica default URL parser.